### PR TITLE
Python 3 support in panos_admpwd

### DIFF
--- a/library/panos_admpwd.py
+++ b/library/panos_admpwd.py
@@ -88,18 +88,19 @@ _PROMPTBUFF = 4096
 
 def wait_with_timeout(module, shell, prompt, timeout=60):
     now = time.time()
-    result = ""
+    result = b""
     while True:
         if shell.recv_ready():
             result += shell.recv(_PROMPTBUFF)
-            endresult = result.strip()
+            resultstr = result.decode("utf-8")
+            endresult = resultstr.strip()
             if len(endresult) != 0 and endresult[-1] == prompt:
                 break
 
         if time.time() - now > timeout:
             module.fail_json(msg="Timeout waiting for prompt")
 
-    return result
+    return resultstr
 
 
 def set_panwfw_password(module, ip_address, key_filename, newpassword, username):


### PR DESCRIPTION
Support Python 3 in panos_admpwd, previously fails with TypeError as recv() in Python 3 returns bytes and not str